### PR TITLE
Add sharing buttons, book cover preview, hero CTA, and UX improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,26 @@
     <section class="hero">
       <h1>Reading What We Can</h1>
       <p class="tagline">Reading lists for the future. The Gauntlet: read 20 books or articles in 20 days.</p>
-      <p class="hero-meta">Post your progress with <a href="https://twitter.com/search?q=%23rwwc" target="_blank">#rwwc</a> &middot; <a href="https://github.com/apartresearch/readingwhatwecan" target="_blank">Contribute on GitHub</a> &middot; A project by <a href="https://apartresearch.com" target="_blank">Apart Research</a></p>
+      <p class="hero-cta"><a href="https://blog.kran.ai/audiovisual-reading" target="_blank">How do I read 20 books in 20 days? &rarr;</a></p>
+      <p class="hero-meta">Post your progress with <a href="https://twitter.com/search?q=%23rwwc" target="_blank">#rwwc</a> &middot; <a href="https://github.com/apartresearch/readingwhatwecan" target="_blank">Contribute on GitHub</a> &middot; A project by <a href="https://kran.ai" target="_blank">Esben Kran</a></p>
+      <div class="share-buttons">
+        <div class="share-group" id="share-start">
+          <button class="share-btn share-main" id="btn-start-challenge">Start Challenge</button>
+          <div class="share-targets" id="targets-start">
+            <button class="share-target" data-platform="twitter" data-action="start">X</button>
+            <button class="share-target" data-platform="linkedin" data-action="start">LinkedIn</button>
+            <button class="share-target" data-platform="copy" data-action="start">Copy</button>
+          </div>
+        </div>
+        <div class="share-group" id="share-progress">
+          <button class="share-btn share-main" id="btn-share-progress">Share Progress</button>
+          <div class="share-targets" id="targets-progress">
+            <button class="share-target" data-platform="twitter" data-action="progress">X</button>
+            <button class="share-target" data-platform="linkedin" data-action="progress">LinkedIn</button>
+            <button class="share-target" data-platform="copy" data-action="progress">Copy</button>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="graph-section">
@@ -44,16 +63,14 @@
         <div id="stats" class="stats"></div>
       </div>
       <div id="contribution-graph" class="contribution-graph"></div>
+      <div id="heatmap-hint" class="heatmap-hint">Check off a book to log your reading progress here</div>
       <div class="graph-footer">
-        <span class="graph-less">Less</span>
         <div class="graph-legend">
           <span class="legend-square" style="background: #161b22"></span>
-          <span class="legend-square" style="background: #0e4429"></span>
-          <span class="legend-square" style="background: #006d32"></span>
-          <span class="legend-square" style="background: #26a641"></span>
+          <span class="legend-label">No activity</span>
           <span class="legend-square" style="background: #39d353"></span>
+          <span class="legend-label">Read</span>
         </div>
-        <span class="graph-more">More</span>
       </div>
     </section>
 
@@ -81,7 +98,7 @@
     </section>
 
     <footer>
-      <p>Originally "The AI Safety Gauntlet" &mdash; a challenge to read 20 books or articles in 20 days as an introduction to AI safety. ReadingWhatWeCan is a spinout from <a href="https://apartresearch.com" target="_blank">Apart Research</a>.</p>
+      <p>Originally "The AI Safety Gauntlet" &mdash; a challenge to read 20 books or articles in 20 days as an introduction to AI safety. A project by <a href="https://kran.ai" target="_blank">Esben Kran</a>, spun out from <a href="https://apartresearch.com" target="_blank">Apart Research</a>.</p>
     </footer>
   </main>
 

--- a/public/script.js
+++ b/public/script.js
@@ -127,6 +127,10 @@ document.addEventListener('DOMContentLoaded', () => {
         pages.className = 'book-pages';
         pages.textContent = entry.page_count ? `${entry.page_count}p` : '';
 
+        if (entry.Image) {
+          row.setAttribute('data-cover', entry.Image);
+        }
+
         row.appendChild(check);
         row.appendChild(num);
         row.appendChild(title);
@@ -207,13 +211,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const svgWidth = LEFT_PAD + actualWeeks * (CELL + GAP);
     const svgHeight = TOP_PAD + 7 * (CELL + GAP);
 
-    const colors = ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'];
     function getColor(count) {
-      if (count === 0) return colors[0];
-      if (count === 1) return colors[1];
-      if (count === 2) return colors[2];
-      if (count === 3) return colors[3];
-      return colors[4];
+      return count > 0 ? '#39d353' : '#161b22';
     }
 
     // Build SVG
@@ -345,6 +344,126 @@ document.addEventListener('DOMContentLoaded', () => {
     renderGraph();
     renderStats();
   }
+
+  // ── Book cover preview on hover ──
+  const coverPreview = document.createElement('div');
+  coverPreview.className = 'cover-preview';
+  coverPreview.style.display = 'none';
+  const coverImg = document.createElement('img');
+  coverPreview.appendChild(coverImg);
+  document.body.appendChild(coverPreview);
+
+  document.addEventListener('mouseenter', (e) => {
+    const row = e.target.closest('.book-row[data-cover]');
+    if (!row) return;
+    const rect = row.getBoundingClientRect();
+    const spaceRight = window.innerWidth - rect.right;
+    if (spaceRight < 180) return; // not enough space
+    coverImg.src = row.getAttribute('data-cover');
+    coverPreview.style.display = 'block';
+    coverPreview.style.top = rect.top + 'px';
+    coverPreview.style.left = (rect.right + 12) + 'px';
+  }, true);
+
+  document.addEventListener('mouseleave', (e) => {
+    const row = e.target.closest('.book-row[data-cover]');
+    if (!row) return;
+    coverPreview.style.display = 'none';
+  }, true);
+
+  // ── Heatmap hint visibility ──
+  function updateHeatmapHint() {
+    const hint = document.getElementById('heatmap-hint');
+    if (!hint) return;
+    const completed = getCompleted();
+    hint.style.display = Object.keys(completed).length === 0 ? 'block' : 'none';
+  }
+
+  // ── Sharing logic ──
+  function getShareText(action) {
+    if (action === 'start') {
+      return "I'm starting a 20 days, 20 books reading challenge on readingwhatwecan.com! I'll review every book in this thread — and if I don't finish, I'll donate $100 to @AMF. Follow along! #rwwc";
+    }
+    // Progress sharing — pick the most impressive stat
+    const completed = getCompleted();
+    const activity = getActivity();
+    const totalCompleted = Object.keys(completed).length;
+    const totalBooks = Object.values(lists).reduce((sum, l) => sum + Math.min(l.data.length, 20), 0);
+
+    // Calculate streak
+    let streak = 0;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const checkDate = new Date(today);
+    const todayKey = checkDate.toISOString().split('T')[0];
+    if (!activity[todayKey]) checkDate.setDate(checkDate.getDate() - 1);
+    while (true) {
+      const key = checkDate.toISOString().split('T')[0];
+      if (activity[key] && activity[key] > 0) {
+        streak++;
+        checkDate.setDate(checkDate.getDate() - 1);
+      } else break;
+    }
+
+    if (streak >= 3) {
+      return `I'm on a ${streak}-day reading streak! ${totalCompleted}/${totalBooks} books done on readingwhatwecan.com #rwwc`;
+    }
+    if (totalCompleted > 0 && totalCompleted / totalBooks > 0.5) {
+      return `I've read ${totalCompleted} out of ${totalBooks} books on readingwhatwecan.com! #rwwc`;
+    }
+    if (totalCompleted > 0 && totalCompleted <= 3) {
+      return `Just started the 20-books-in-20-days challenge on readingwhatwecan.com! ${totalCompleted} down, ${totalBooks - totalCompleted} to go. #rwwc`;
+    }
+    if (totalCompleted > 0) {
+      return `I've completed ${totalCompleted} readings on readingwhatwecan.com so far! #rwwc`;
+    }
+    return "I'm about to start the 20-books-in-20-days challenge on readingwhatwecan.com! #rwwc";
+  }
+
+  function shareToTwitter(text) {
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, '_blank');
+  }
+
+  function shareToLinkedIn(text) {
+    window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://readingwhatwecan.com')}&summary=${encodeURIComponent(text)}`, '_blank');
+  }
+
+  function copyToClipboard(text, btn) {
+    navigator.clipboard.writeText(text).then(() => {
+      const orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    });
+  }
+
+  // Toggle share targets visibility
+  document.querySelectorAll('.share-main').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const group = btn.closest('.share-group');
+      group.classList.toggle('open');
+    });
+  });
+
+  // Handle share target clicks
+  document.querySelectorAll('.share-target').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const action = btn.getAttribute('data-action');
+      const platform = btn.getAttribute('data-platform');
+      const text = getShareText(action);
+      if (platform === 'twitter') shareToTwitter(text);
+      else if (platform === 'linkedin') shareToLinkedIn(text);
+      else if (platform === 'copy') copyToClipboard(text, btn);
+    });
+  });
+
+  // ── Render all (updated to include hint) ──
+  const origRenderAll = renderAll;
+  renderAll = function() {
+    renderBooks();
+    renderGraph();
+    renderStats();
+    updateHeatmapHint();
+  };
 
   // Initial render
   renderAll();

--- a/public/style.css
+++ b/public/style.css
@@ -137,9 +137,90 @@ main {
   text-underline-offset: 2px;
 }
 
+.hero-cta {
+  margin-bottom: 8px;
+}
+
+.hero-cta a {
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hero-cta a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .hero-meta a:hover {
   color: var(--accent);
   text-decoration-color: var(--accent);
+}
+
+/* Share buttons */
+.share-buttons {
+  display: flex;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.share-group {
+  position: relative;
+}
+
+.share-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-light);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.share-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.share-targets {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  z-index: 50;
+  white-space: nowrap;
+}
+
+.share-group.open .share-targets {
+  display: flex;
+}
+
+.share-target {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-right: 1px solid var(--border);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.share-target:last-child {
+  border-right: none;
+}
+
+.share-target:hover {
+  color: var(--accent);
+  background: var(--hover-bg);
 }
 
 /* Contribution Graph */
@@ -196,6 +277,29 @@ main {
   font-family: 'JetBrains Mono', monospace;
 }
 
+/* Heatmap hint */
+.heatmap-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-style: italic;
+  padding: 6px 0;
+}
+
+/* Book cover preview */
+.cover-preview {
+  position: fixed;
+  z-index: 300;
+  pointer-events: none;
+  max-width: 150px;
+}
+
+.cover-preview img {
+  width: 150px;
+  height: auto;
+  border: 1px solid var(--border-light);
+  display: block;
+}
+
 .graph-footer {
   display: flex;
   align-items: center;
@@ -218,8 +322,8 @@ main {
   display: inline-block;
 }
 
-.graph-less, .graph-more {
-  margin: 0 4px;
+.legend-label {
+  margin-right: 8px;
 }
 
 /* Tabs */
@@ -320,8 +424,8 @@ main {
 }
 
 .book-row.completed .check-box {
-  background: var(--green-3);
-  border-color: var(--green-3);
+  background: var(--accent);
+  border-color: var(--accent);
 }
 
 .book-row.completed .check-box::after {


### PR DESCRIPTION
- Heatmap uses binary green (any activity = full green #39d353)
- Checkbox checkmark now full bright green instead of dark green
- Hero CTA links to blog post on audiovisual reading method
- Attribution updated to Esben Kran linking to kran.ai
- Start Challenge button generates pre-filled tweet with $100 AMF pledge
- Share Progress button picks most impressive stat contextually
- Book cover images preview on hover (scifi list, right side if space)
- Heatmap shows hint text when empty, hides once books are checked
- Legend simplified to binary (No activity / Read)

https://claude.ai/code/session_01LMfXRyN5vgfidMCbMm2ezA