### PR TITLE
Refactor date formatting to use local timezone instead of ISO

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -23,8 +23,15 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem(STORAGE_KEY_ACTIVITY, JSON.stringify(data));
   }
 
+  function toLocalDateStr(date) {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
   function todayStr() {
-    return new Date().toISOString().split('T')[0];
+    return toLocalDateStr(new Date());
   }
 
   // ── Toggle book completion ──
@@ -242,7 +249,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Skip future dates
         if (cellDate > today) continue;
 
-        const dateStr = cellDate.toISOString().split('T')[0];
+        const dateStr = toLocalDateStr(cellDate);
         const count = activity[dateStr] || 0;
         const x = LEFT_PAD + w * (CELL + GAP);
         const y = TOP_PAD + d * (CELL + GAP);
@@ -304,13 +311,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const checkDate = new Date(today);
 
     // Check if today has activity; if not, start from yesterday
-    const todayKey = checkDate.toISOString().split('T')[0];
+    const todayKey = toLocalDateStr(checkDate);
     if (!activity[todayKey]) {
       checkDate.setDate(checkDate.getDate() - 1);
     }
 
     while (true) {
-      const key = checkDate.toISOString().split('T')[0];
+      const key = toLocalDateStr(checkDate);
       if (activity[key] && activity[key] > 0) {
         streak++;
         checkDate.setDate(checkDate.getDate() - 1);
@@ -395,10 +402,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const checkDate = new Date(today);
-    const todayKey = checkDate.toISOString().split('T')[0];
+    const todayKey = toLocalDateStr(checkDate);
     if (!activity[todayKey]) checkDate.setDate(checkDate.getDate() - 1);
     while (true) {
-      const key = checkDate.toISOString().split('T')[0];
+      const key = toLocalDateStr(checkDate);
       if (activity[key] && activity[key] > 0) {
         streak++;
         checkDate.setDate(checkDate.getDate() - 1);


### PR DESCRIPTION
## Summary
This PR refactors date-to-string conversions throughout the codebase to use local timezone instead of UTC/ISO format. This ensures that dates are consistently represented in the user's local timezone rather than being converted to UTC.

## Key Changes
- **New utility function**: Added `toLocalDateStr()` helper function that converts a Date object to a `YYYY-MM-DD` string using the local timezone (via `getFullYear()`, `getMonth()`, and `getDate()`)
- **Replaced ISO conversions**: Updated all instances of `date.toISOString().split('T')[0]` to use the new `toLocalDateStr()` function across:
  - `todayStr()` function
  - Activity calendar rendering logic
  - Streak calculation logic (2 locations)
  - Activity tracking logic

## Implementation Details
The new `toLocalDateStr()` function properly handles:
- Zero-padding for month and day values using `padStart(2, '0')`
- Local timezone conversion instead of UTC conversion
- Consistent date string format (`YYYY-MM-DD`) matching the previous ISO format output

This change prevents timezone-related bugs where users in different timezones could see inconsistent activity dates, particularly around midnight boundaries.

https://claude.ai/code/session_01HWJCcMUck2F3Xqtb7hQARM